### PR TITLE
Add vagrant support

### DIFF
--- a/about.md
+++ b/about.md
@@ -1,0 +1,20 @@
+---
+layout: page
+title: Who We Are
+---
+
+We are a community of computer science and computer engineering students dedicated to honing our craft. We meet regularly to share what we’re learning, discuss developments in our field, and build things. [Talk to us.][contact]
+
+What we do
+==========
+
++	[Education][education]: We host student-run workshops to introduce each other to new tools and best practices.
+
++	[Projects][projects]: We form teams and master new technologies.
+
++	[Networking][networking]: We like each other, so we hang out. We also like meeting technologists from around Pittsburgh.
+
+[contact]:	/index.html
+[education]:	/index.html
+[projects]:	/index.html
+[networking]:	/index.html


### PR DESCRIPTION
As an exercise in Vagrant, I added a Vagrantfile and provisioning script. They'll set up an environment necessary to locally serve a Jekyll page using the same settings as Github Pages. After typing 'vagrant up' and waiting patiently for ~30 minutes, you should be able to browse to http://127.0.0.1:4567/ and see the site. I think we can improve on this first attempt by using a box that already has some of the tools installed. Still, take a look and bring it in if you think it could be useful.
